### PR TITLE
Update Kanidm.php

### DIFF
--- a/src/Provider/Kanidm.php
+++ b/src/Provider/Kanidm.php
@@ -101,5 +101,16 @@ class Kanidm extends GenericProvider
             'email',
             'profile',
         ];
-    }    
+    }
+    
+    /**
+     * Returns the string that should be used to separate scopes when building
+     * the URL for requesting an access token.
+     *
+     * @return string Scope separator, defaults to ','
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
 }


### PR DESCRIPTION
changed default ScopeSeparator from `,` to ` `.